### PR TITLE
created migration to add photo url to doppelgangers

### DIFF
--- a/db/migrate/20210817031322_add_image_to_doppelgangers.rb
+++ b/db/migrate/20210817031322_add_image_to_doppelgangers.rb
@@ -1,0 +1,5 @@
+class AddImageToDoppelgangers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :doppelgangers, :photo_url, :string
+  end
+end


### PR DESCRIPTION
Please check if this works for you. Just added a new migration file so it adds a photo_url to the doppelgangers so I can use it in the seeds