### PR TITLE
Took out hard coded text for the prices

### DIFF
--- a/app/views/shared/_doppelgangercard.html.erb
+++ b/app/views/shared/_doppelgangercard.html.erb
@@ -11,7 +11,8 @@
       <div class="card-product-price">
       <div>
         <p><%= "¥#{doppelganger.price} / hour" %></p>
-        <p class="total-price">4,000 total (hard coded)</p>
+        <p class="total-price">4,000 total</p>
+        <%# Above price is hard coded %>
       </div>
       </div>
     </div>


### PR DESCRIPTION
Took out the "hard coded" text on the doppelganger cards on index page
<img width="647" alt="Screen Shot 2021-08-18 at 16 11 58" src="https://user-images.githubusercontent.com/84015779/129854144-10056b0a-bf0c-4642-91e1-72b0947c94f9.png">
