### PR TITLE
Remove extra dotenv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem "pundit"
 gem 'font-awesome-sass'
 gem 'simple_form'
 gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'master'
-gem 'dotenv-rails', groups: [:development, :test]
 gem 'cloudinary', '~> 1.16.0'
 
 


### PR DESCRIPTION
Removes extra dotenv-rails from the gemfile. Heroku complained, so I'm changing it. Should function the same