### PR TITLE
Make home cards clickable

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -5,6 +5,9 @@
       <div class="col">
         <div class="container my-3">
           <div class="card-product">
+            <div>
+               <%= link_to '', doppelganger_path(doppelganger), class: 'card-link' %>
+            </div>
           <%= cl_image_tag doppelganger.photo.key, height: 800, width: 800, crop: :fill  %>
             <div class="card-product-infos">
               <div class="card-product-title">


### PR DESCRIPTION
Makes cards on the home page clickable. Routes to the show page for doppelganger on card.
<img width="1440" alt="Screen Shot 2021-08-20 at 12 50 44" src="https://user-images.githubusercontent.com/69414602/130176381-9e61cd7e-9e76-4edb-a58d-be7551106db0.png">
