### PR TITLE
Added a border around nav button

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -18,3 +18,8 @@
   color: $steel-teal;
   font-size: 16px;
 }
+
+.button-outline {
+  border: 1px solid grey;
+  border-radius: 30px;
+}

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -22,4 +22,11 @@
 .button-outline {
   border: 1px solid grey;
   border-radius: 30px;
+  padding: 8px;
+    &:hover {
+      text-decoration: none;
+      background-color: $steel-teal;
+      border: 1px solid $steel-teal;
+      color:white
+    }
 }

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -30,7 +30,7 @@
           </div>
         </li>
       <li class="nav-item mt-1">
-        <%= link_to "Become a Doppelganger", "/doppelgangers/new", class: "dropdown-item button-outline" %>
+        <%= link_to "Become a Doppelganger", "/doppelgangers/new", class: "button-outline" %>
       </li>
         <li class="nav-item">
           <%= link_to destroy_user_session_path, method: :delete, class: "nav-link" do %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -30,7 +30,7 @@
           </div>
         </li>
       <li class="nav-item mt-1">
-        <%= link_to "Become a Doppelganger", "/doppelgangers/new", class: "dropdown-item" %>
+        <%= link_to "Become a Doppelganger", "/doppelgangers/new", class: "dropdown-item button-outline" %>
       </li>
         <li class="nav-item">
           <%= link_to destroy_user_session_path, method: :delete, class: "nav-link" do %>


### PR DESCRIPTION
Added a border around "become a doppelganger" button in navbar
Full-screen
<img width="455" alt="Screen Shot 2021-08-20 at 13 47 13" src="https://user-images.githubusercontent.com/84015779/130180547-a3b0ed4c-a7d2-44d5-b6a5-efee3863c779.png">

Smaller-screen
<img width="491" alt="Screen Shot 2021-08-20 at 13 47 27" src="https://user-images.githubusercontent.com/84015779/130180566-ef030e9a-d103-4531-a2fd-ed98f0b873c7.png">
